### PR TITLE
Fixes for stuff broken with latest merge

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -28,7 +28,7 @@ include-naming-hint=yes
 [FORMAT]
 
 expected-line-ending-format=LF
-max-line-length=79
+max-line-length=120
 
 
 [MISCELLANEOUS]

--- a/esi_bot/__init__.py
+++ b/esi_bot/__init__.py
@@ -1,6 +1,5 @@
 """ESI Slack bot."""
 
-
 # pylint: disable=unused-argument,wrong-import-position,wrong-import-order
 from gevent import monkey
 monkey.patch_all()
@@ -16,11 +15,11 @@ from concurrent.futures import ThreadPoolExecutor  # noqa E402
 import requests  # noqa E402
 from requests.adapters import HTTPAdapter  # noqa E402
 
-
 LOG = logging.getLogger(__name__)
-LOG.setLevel(getattr(logging, os.environ.get("ESI_BOT_LOG_LEVEL", "INFO")))
+LOG_LEVEL = getattr(logging, os.environ.get("ESI_BOT_LOG_LEVEL", "INFO"))
+LOG.setLevel(LOG_LEVEL)
 logging.basicConfig(
-    level=logging.INFO,
+    level=LOG_LEVEL,
     format="%(asctime)s:%(name)s:%(levelname)s: %(message)s",
 )
 

--- a/esi_bot/bot.py
+++ b/esi_bot/bot.py
@@ -1,6 +1,5 @@
 """ESI slack bot for tweetfleet."""
 
-
 import os
 import time
 
@@ -11,16 +10,8 @@ from esi_bot import ESI_CHINA
 from esi_bot import LOG
 from esi_bot import request
 from esi_bot.processor import Processor
-from esi_bot.commands import (  # pylint: disable=unused-import;  # noqa F401
-    get_help,
-    issue_details,
-    issue_new,
-    links,
-    misc,
-    status_esi,
-    status_server,
-    type_info
-)
+from esi_bot.commands import (  # noqa: F401;  # pylint: disable=unused-import
+    get_help, issue_details, issue_new, status_esi, status_server, type_info)
 
 
 def main():

--- a/esi_bot/commands/__init__.py
+++ b/esi_bot/commands/__init__.py
@@ -1,0 +1,1 @@
+"""ESI Slack bot commands."""

--- a/esi_bot/processor.py
+++ b/esi_bot/processor.py
@@ -1,6 +1,5 @@
 """Message processing for ESI-bot."""
 
-
 import os
 import re
 import time
@@ -16,7 +15,6 @@ from esi_bot import MESSAGE
 from esi_bot import COMMANDS
 from esi_bot.users import Users
 from esi_bot.channels import Channels
-
 
 STARTUP_MSGS = (
     "hello, world",
@@ -45,9 +43,10 @@ STARTUP_MSGS = (
 )
 
 REACTION_TRIGGERS = {
-    re.compile(r"(?:^|[\W_])crest(?:$|[\W_])", re.IGNORECASE): "rip",
-    re.compile(r"(?:^|[\W_])xml(?:[\W_]?api)?(?:$|[\W_])",
-               re.IGNORECASE): "wreck",
+    re.compile(r"(?:^|[\W_])crest(?:$|[\W_])", re.IGNORECASE):
+        "rip",
+    re.compile(r"(?:^|[\W_])xml(?:[\W_]?api)?(?:$|[\W_])", re.IGNORECASE):
+        "wreck",
 }
 
 UNMATCHED = object()
@@ -55,7 +54,6 @@ UNMATCHED = object()
 
 class Processor:
     """Execute ESI-bot commands based on incoming messages."""
-
     def __init__(self, slack):
         """Create a new processor instance."""
 
@@ -117,7 +115,7 @@ class Processor:
         """Send a snippet to the channel, or the primary channel."""
 
         # There is a 1 megabyte file size limit for files uploaded as snippets.
-        megb = 1024 ** 2
+        megb = 1024**2
         if len(reply.content) > megb:
             snip = "<snipped>"
             content = "{}{}".format(reply.content[:megb - len(snip)], snip)
@@ -230,7 +228,7 @@ class Processor:
             return False
 
         user_name = self._users.get_name(user)
-        LOG.info(
+        LOG.debug(
             "[%s] @%s: %s",
             datetime.utcfromtimestamp(int(float(timestamp))),
             user_name,

--- a/esi_bot/request.py
+++ b/esi_bot/request.py
@@ -86,7 +86,7 @@ def request(match, msg):
         except ValueError:
             status = str(res.status_code)
         else:
-            status = "{} {}".format(status.value, status.name)
+            status = "{} {}".format(status.value, status.name)  # pylint: disable=E1101
 
         if "--headers" in msg.args:
             res = {"response": content, "headers": dict(res.headers)}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-slackclient>=1.2.1
+slackclient==1.3.2
 requests>=2.18.4
 setuphelpers>=0.1.2
 gevent>=1.2.2

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,11 @@
 """ESI slack bot."""
 
-
 import os
 from setuptools import setup
 from setuptools import find_packages
 from setuphelpers import git_version
 from setuphelpers import test_command
 from setuphelpers import long_description
-
 
 setup(
     name="esi-bot",
@@ -22,7 +20,7 @@ setup(
     download_url="https://github.com/esi/esi-bot/",
     install_requires=[
         "requests >= 2.18.4",
-        "slackclient >= 1.2.1",
+        "slackclient == 1.3.2",
         "gevent >= 1.2.2",
     ],
     setup_requires=["setuphelpers >= 0.1.2"],

--- a/tox.ini
+++ b/tox.ini
@@ -26,3 +26,4 @@ addopts = -rx -rs -v --cov-report term-missing
 [flake8]
 exclude = *.pyc,.svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.ropeproject,.idea,.venv*,.pypy
 ignore = E123,D202,D203,D413
+max-line-length = 120


### PR DESCRIPTION
- Sets some ignore lint checks comments and sets max line length to 120.
- Esi-bot is not currently compatible with `slackclient` major version 2.
  1.3.2 is a latest major version 1.
- Modifies setting the log level to respect env var.
- Changes log level for all events INFO->DEBUG.