### PR TITLE
Remove legacy commands

### DIFF
--- a/esi_bot/bot.py
+++ b/esi_bot/bot.py
@@ -11,7 +11,7 @@ from esi_bot import LOG
 from esi_bot import request
 from esi_bot.processor import Processor
 from esi_bot.commands import (  # noqa: F401;  # pylint: disable=unused-import
-    get_help, issue_details, issue_new, status_esi, status_server, type_info)
+    get_help, issue_details, issue_new, links, misc, status_esi, status_server, type_info)
 
 
 def main():

--- a/esi_bot/commands/links.py
+++ b/esi_bot/commands/links.py
@@ -19,13 +19,6 @@ def ids(*_):
 
 
 @command
-def waffle(*_):
-    """Return a link to the ESI issues waffle board."""
-
-    return "https://waffle.io/esi/esi-issues"
-
-
-@command
 def faq(*_):
     """Return a link to the ESI issues FAQ."""
 
@@ -51,16 +44,6 @@ def webui(msg):
     """Return a link to the ui (v3)."""
 
     return "{}/ui/".format(esi_base_url(msg))
-
-
-@command(trigger=("legacy", "v2ui"))
-def legacy(msg):
-    """Return links to the old v2 ui."""
-
-    return (
-        "Legacy (v2) UIs are still available at {esi}/latest/ "
-        "{esi}/dev/ and {esi}/legacy/"
-    ).format(esi=esi_base_url(msg))
 
 
 @command(trigger=("diff", "diffs"))

--- a/esi_bot/commands/status_server.py
+++ b/esi_bot/commands/status_server.py
@@ -16,13 +16,6 @@ def tranquility(*_):
     return server_status("tranquility")
 
 
-@command(trigger=("sisi", "singularity"))
-def singularity(*_):
-    """Display current status of Singularity, the main test server."""
-
-    return server_status("singularity")
-
-
 @command
 def serenity(*_):
     """Display current status of Serenity, the main server in China."""
@@ -33,7 +26,7 @@ def serenity(*_):
 def server_status(datsource):
     """Generate a reply describing the status of an EVE server/datasource."""
 
-    if datsource in ("tranquility", "singularity"):
+    if datsource == "tranquility":
         base_url = ESI
     elif datsource == "serenity":
         base_url = ESI_CHINA

--- a/esi_bot/request.py
+++ b/esi_bot/request.py
@@ -31,7 +31,7 @@ ESI_SPECS = {
 
 
 @command(trigger=re.compile(
-    r"^<?(?P<esi>https://esi\.(evetech\.net|tech\.ccp\.is|evepc\.163\.com))?"
+    r"^<?(?P<esi>https://esi\.(evetech\.net|evepc\.163\.com))?"
     r"/(?P<esi_path>.+?)>?$"
 ))
 def request(match, msg):


### PR DESCRIPTION
- Restore command imports accidentally deleted in e76b282
- Remove the following commands
  - waffle (no longer used)
  - legacy (UI no longer in use)
  - singularity (singularity datasource no longer supported)
- Remove reference to old esi.tech.ccp.is domain which has been removed.